### PR TITLE
domain field as new data type, based on pimcore select

### DIFF
--- a/Model/MultiDomainDataType.php
+++ b/Model/MultiDomainDataType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Basilicom\MultiDomainBundle\Model;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Select;
+
+class MultiDomainDataType extends Select
+{
+    /**
+     * Static type of this element
+     *
+     * @var string
+     */
+    public $fieldtype = 'multiDomainSelect';
+}

--- a/Resources/config/pimcore/config.yaml
+++ b/Resources/config/pimcore/config.yaml
@@ -1,0 +1,6 @@
+pimcore:
+  objects:
+    class_definitions:
+      data:
+        map:
+          myDataType: \Basilicom\MultiDomainBundle\Model\MultiDomainDataType

--- a/Resources/public/js/pimcore/startup.js
+++ b/Resources/public/js/pimcore/startup.js
@@ -15,3 +15,25 @@ pimcore.plugin.BasilicomMultiDomainBundle = Class.create(pimcore.plugin.admin, {
 });
 
 var BasilicomMultiDomainBundlePlugin = new pimcore.plugin.BasilicomMultiDomainBundle();
+
+pimcore.registerNS("pimcore.object.classes.data.multiDomainSelect");
+pimcore.object.classes.data.multiDomainSelect = Class.create(pimcore.object.classes.data.select, {
+    type: "multiDomainSelect",
+    allowIn: {
+        object: true
+    },
+    initialize: function (treeNode, initData) {
+        this.type = "multiDomainSelect";
+        this.initData(initData);
+        this.treeNode = treeNode;
+    },
+    getTypeName: function () {
+        return t("multiDomainSelect");
+    },
+    getGroup: function () {
+        return "relation";
+    },
+    getIconClass: function () {
+        return "pimcore_icon_gridconfig_class_attributes";
+    }
+});

--- a/Resources/translations/admin.de.yaml
+++ b/Resources/translations/admin.de.yaml
@@ -1,0 +1,1 @@
+multiDomainSelect: Multi-Domain-Select

--- a/Resources/translations/admin.en.yaml
+++ b/Resources/translations/admin.en.yaml
@@ -1,0 +1,1 @@
+multiDomainSelect: Multi-Domain-Select


### PR DESCRIPTION
Made recommendations and some steps for implementation redundant by creating new Pimcore DataType `multiDomainSelect`.

![Bildschirmfoto 2020-08-03 um 10 00 47](https://user-images.githubusercontent.com/9350895/89159794-4cd06280-d570-11ea-997d-7a922f684e82.png)
